### PR TITLE
Use HTTPS instead of HTTPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Trusting SDKs - HTTPs
+# Trusting SDKs - HTTPS
 
-A crowd-sourced list of SDKs and how they protect their downloads with HTTPs.
+A crowd-sourced list of SDKs and how they protect their downloads with HTTPS.
 
 Based on the [Trusting SDKs post](https://krausefx.com/blog/trusting-sdks) by [@KrauseFx](https://twitter.com/KrauseFx) this repo contains a crowd-sourced list of SDKs and their status when it comes to security when downloading the binary or source code.
 
@@ -8,7 +8,7 @@ Based on the [Trusting SDKs post](https://krausefx.com/blog/trusting-sdks) by [@
 
 You can get a list of the most used iOS SDKs on [AppSight](https://www.appsight.io/?asot=2&o=top&os=ios)
 
-| SDK | Has official CocoaPod | Website that links encrypted | Download uses HTTPs | Open Source |
+| SDK | Has official CocoaPod | Website that links encrypted | Download uses HTTPS | Open Source |
 | --- | :---: | :---: | :---: | :---: |
 | [Facebook SDK](https://developers.facebook.com/docs/ios/) | ✅ | ✅ | ✅ | ✅ |
 | [AWS SDK](https://aws.amazon.com/documentation/sdk-for-ios/) | ✅ | ✅ | ✅ | ⚠️ |
@@ -38,19 +38,19 @@ As soon as the pod is maintained by a third party, the SDK is out of the control
 
 #### Website that links encrypted
 
-- ✅ The website linking to the download of the SDK (or the CocoaPods page) is HTTPs encrypted by default
+- ✅ The website linking to the download of the SDK (or the CocoaPods page) is HTTPS encrypted by default
 - ❌ The website linking to the download uses unencrypted HTTP
 
 This is critical, as by having the marketing or docs page be unencrypted allows an attack to re-write any links to different URLs, as described in [trusting SDKs](https://krausefx.com/blog/trusting-sdks) in the `Localytics` section.
 
-#### Download uses HTTPs
+#### Download uses HTTPS
 
 This section is about the `Manual Installation` section most SDKs provides. As mentioned in [trusting SDKs](https://krausefx.com/blog/trusting-sdks) most of the pods on CocoaPods are secure.
 
-- ✅ The download of the SDK happens via HTTPs by default
-- ❌ The download of the SDK uses unencrypted HTTP by default, or doesn't support HTTPs at all
+- ✅ The download of the SDK happens via HTTPS by default
+- ❌ The download of the SDK uses unencrypted HTTP by default, or doesn't support HTTPS at all
 
-If the download doesn't happen via HTTPs be extra cautios when using the SDK, and notify the SDK provider.
+If the download doesn't happen via HTTPS be extra cautious when using the SDK, and notify the SDK provider.
 
 #### Open Source
 


### PR DESCRIPTION
HTTPS seems to be the more common usage of the initialism over HTTPs. I'm open to other opinions, however.