### PR TITLE
Adds Zendesk Support and Chat SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ You can get a list of the most used iOS SDKs on [AppSight](https://www.appsight.
 | [PSPDFKit for iOS/macOS](https://pspdfkit.com/)| ✅ | ✅ | ✅ | ⚠️ |
 | [Instabug](https://instabug.com/)| ✅ | ✅ | ✅ | ⚠️ |
 | [Intercom iOS SDK](https://github.com/intercom/intercom-ios)| ✅ | ✅ | ✅ | ⚠️ |
+| [Zendesk Support SDK](https://github.com/zendesk/zendesk_sdk_ios)| ✅ | ✅ | ✅ | ⚠️ |
+| [Zendesk Chat SDK](https://github.com/zendesk/zendesk_sdk_chat_ios)| ✅ | ✅ | ✅ | ⚠️ |
 
 #### Has official CocoaPod
 


### PR DESCRIPTION
Adding Zendesk Support and Chat SDKs. Both are distributed manually via Github, and by CocoaPods also.