### PR TITLE
Remove HockeyApp SDK 😢

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ You can get a list of the most used iOS SDKs on [AppSight](https://www.appsight.
 | [AskingPoint](https://www.askingpoint.com/documentation-ios-sdk/) | ❌ | ✅ | ❌ | ⚠️ |
 | [Google Analytics](https://developers.google.com/analytics/devguides/collection/ios/v3/) | ✅ | ✅ | ✅ | ⚠️ |
 | [Customerly SDK](https://www.customerly.io/customers-intelligence) | ✅ | ✅ | ✅ | ✅ |
-| [HockeyApp](https://github.com/bitstadium/HockeySDK-iOS#readme) | ✅ | ✅ | ✅ | ✅ |
 | [VS App Center](https://github.com/Microsoft/appcenter-sdk-apple#readme) | ✅ | ✅ | ✅ | ✅ |
 | [Evernote SDK](https://github.com/evernote/evernote-cloud-sdk-ios) | ✅ | ✅ | ✅ | ✅ |
 | [Carnival SDK](https://github.com/carnivalmobile/carnival-ios-sdk/)| ✅ | ✅ | ✅ | ⚠️ |


### PR DESCRIPTION
HockeyApp has been shut down and the SDK is deprecated.